### PR TITLE
Perl adam sync

### DIFF
--- a/perl-package/AI-MXNet/lib/AI/MXNet/Optimizer.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Optimizer.pm
@@ -643,7 +643,9 @@ __PACKAGE__->register;
         Default value is set to 1e-8.
     decay_factor : float, optional
         Default value is set to 1 - 1e-8.
-
+    rho : float, optional
+        Shrinkage rate for beta1 when calculate the mean.
+        Default value is set to 1 - 1e-8.
     wd : float, optional
         L2 regularization coefficient add to all the weights
     rescale_grad : float, optional
@@ -662,6 +664,7 @@ has '+learning_rate' => (default => 0.001);
 has 'beta1'    => (is => "rw", isa => "Num", default => 0.9);
 has 'beta2'    => (is => "rw", isa => "Num", default => 0.999);
 has 'epsilon'  => (is => "rw", isa => "Num", default => 1e-8);
+has 'rho'      => (is => "rw", isa => "Num", default => (1 - 1e-8));
 has 'decay_factor'  => (is => "rw", isa => "Num", default => (1 - 1e-8));
 
 sub BUILD
@@ -707,6 +710,7 @@ method update(
     my $t = $self->_index_update_count->{$index};
     my $coef1 = 1 - $self->beta1**$t;
     my $coef2 = 1 - $self->beta2**$t;
+    my $rho   = $self->rho**($t-1);
     $lr *= sqrt($coef2)/$coef1;
     my ($mean, $var) = @{ $state };
     AI::MXNet::NDArray->adam_update(
@@ -715,6 +719,7 @@ method update(
             out => $weight,
             lr  => $lr,
             wd  => $wd,
+            rho => $rho,
             %{ $self->kwargs }
         }
     );

--- a/perl-package/AI-MXNet/t/test_optimizers.t
+++ b/perl-package/AI-MXNet/t/test_optimizers.t
@@ -8,6 +8,7 @@ extends 'AI::MXNet::Optimizer';
 has 'beta1' => (is => 'rw', default => 0.9);
 has 'beta2' => (is => 'rw', default => 0.999);
 has 'epsilon' => (is => 'rw', default => 1e-8);
+has 'rho' => (is => 'rw', default => (1-1e-8));
 has 'rescale_grad' => (is => 'rw', default => 1);
 has 'decay_factor' => (is => 'rw', default => (1-1e-8));
 around BUILDARGS => \&init;
@@ -64,8 +65,8 @@ method update($index, $weight, $grad, $state)
     {
         mx->nd->clip($grad, -$self->clip_gradient, $self->clip_gradient, { out => $grad });
     }
-    $mean *= $self->beta1;
-    $mean += $grad * (1 - $self->beta1);
+    $mean *= $self->beta1 * $self->rho**($t-1);
+    $mean += $grad * (1 - $self->beta1 * $self->rho**($t-1));
 
     $variance *= $self->beta2;
     $variance += (1 - $self->beta2) * mx->nd->square($grad, { out => $grad });

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -588,7 +588,7 @@ class Adam(Optimizer):
     The optimizer updates the weight by::
 
         rescaled_grad = clip(grad * rescale_grad + wd * weight, clip_gradient)
-        m = beta1 * m + (1 - beta1 * lambda^(t-1)) * rescaled_grad
+        m = beta1 * rho**(t-1) * m + (1 - beta1 * rho**(t-1)) * rescaled_grad
         v = beta2 * v + (1 - beta2) * (rescaled_grad**2)
         w = w - learning_rate * m / (sqrt(v) + epsilon)
 
@@ -597,7 +597,7 @@ class Adam(Optimizer):
 
         for row in grad.indices:
             rescaled_grad[row] = clip(grad[row] * rescale_grad + wd * weight[row], clip_gradient)
-            m[row] = beta1 * m[row] + (1 - beta1 * lambda^(t-1)) * rescaled_grad[row]
+            m[row] = beta1 * rho**(t-1) * m[row] + (1 - beta1 * rho**(t-1)) * rescaled_grad[row]
             v[row] = beta2 * v[row] + (1 - beta2) * (rescaled_grad[row]**2)
             w[row] = w[row] - learning_rate * m[row] / (sqrt(v[row]) + epsilon)
 

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -588,7 +588,7 @@ class Adam(Optimizer):
     The optimizer updates the weight by::
 
         rescaled_grad = clip(grad * rescale_grad + wd * weight, clip_gradient)
-        m = beta1 * m + (1 - beta1) * rescaled_grad
+        m = beta1 * m + (1 - beta1 * lambda^(t-1)) * rescaled_grad
         v = beta2 * v + (1 - beta2) * (rescaled_grad**2)
         w = w - learning_rate * m / (sqrt(v) + epsilon)
 
@@ -597,7 +597,7 @@ class Adam(Optimizer):
 
         for row in grad.indices:
             rescaled_grad[row] = clip(grad[row] * rescale_grad + wd * weight[row], clip_gradient)
-            m[row] = beta1 * m[row] + (1 - beta1) * rescaled_grad[row]
+            m[row] = beta1 * m[row] + (1 - beta1 * lambda^(t-1)) * rescaled_grad[row]
             v[row] = beta2 * v[row] + (1 - beta2) * (rescaled_grad[row]**2)
             w[row] = w[row] - learning_rate * m[row] / (sqrt(v[row]) + epsilon)
 
@@ -608,18 +608,23 @@ class Adam(Optimizer):
 
     Parameters
     ----------
+    learning_rate : float, optional
+        Learning rate.
     beta1 : float, optional
         Exponential decay rate for the first moment estimates.
     beta2 : float, optional
         Exponential decay rate for the second moment estimates.
+    rho : float, optional
+        Shrinkage rate for beta1 when calculate the mean.
     epsilon : float, optional
         Small value to avoid division by 0.
     """
-    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8,
-                 **kwargs):
+    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999,
+                 rho=1-1e-8, epsilon=1e-8, **kwargs):
         super(Adam, self).__init__(learning_rate=learning_rate, **kwargs)
         self.beta1 = beta1
         self.beta2 = beta2
+        self.rho = rho
         self.epsilon = epsilon
 
     def create_state(self, index, weight):
@@ -639,8 +644,10 @@ class Adam(Optimizer):
         coef1 = 1. - self.beta1**t
         coef2 = 1. - self.beta2**t
         lr *= math.sqrt(coef2)/coef1
+        rho = self.rho**(t-1)
 
-        kwargs = {'beta1': self.beta1, 'beta2': self.beta2, 'epsilon': self.epsilon,
+        kwargs = {'beta1': self.beta1, 'beta2': self.beta2,
+                  'rho': rho, 'epsilon': self.epsilon,
                   'rescale_grad': self.rescale_grad}
         if self.clip_gradient:
             kwargs['clip_gradient'] = self.clip_gradient

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -694,7 +694,8 @@ inline void AdamUpdate(const nnvm::NodeAttrs& attrs,
       var = scalar<DType>(param.beta2)*var + scalar<DType>(1.f-param.beta2)*F<square>(
           F<clip>(grad, DType(param.clip_gradient)));
     } else {
-      mean = scalar<DType>(param.beta1*param.rho)*mean + scalar<DType>(1.f-param.beta1*param.rho) * grad;
+      mean = scalar<DType>(param.beta1*param.rho)*mean +
+             scalar<DType>(1.f-param.beta1*param.rho) * grad;
       var = scalar<DType>(param.beta2)*var + scalar<DType>(1.f-param.beta2) * F<square>(grad);
     }
     Assign(out, req[0],

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -631,6 +631,7 @@ struct AdamParam : public dmlc::Parameter<AdamParam> {
   float lr;
   float beta1;
   float beta2;
+  float rho;
   float epsilon;
   float wd;
   float rescale_grad;
@@ -647,6 +648,9 @@ struct AdamParam : public dmlc::Parameter<AdamParam> {
     DMLC_DECLARE_FIELD(epsilon)
     .set_default(1e-8f)
     .describe("A small constant for numerical stability.");
+    DMLC_DECLARE_FIELD(rho)
+    .set_default(1.0 - 1e-8f)
+    .describe("Shrinkage rate for beta1.");
     DMLC_DECLARE_FIELD(wd)
     .set_default(0.0f)
     .describe("Weight decay augments the objective function with a "
@@ -685,12 +689,12 @@ inline void AdamUpdate(const nnvm::NodeAttrs& attrs,
       scalar<DType>(param.wd) * weight;
 
     if (param.clip_gradient >= 0.0f) {
-      mean = scalar<DType>(param.beta1)*mean + scalar<DType>(1.f-param.beta1) *
+      mean = scalar<DType>(param.beta1*param.rho)*mean + scalar<DType>(1.f-param.beta1*param.rho) *
           F<clip>(grad, DType(param.clip_gradient));
       var = scalar<DType>(param.beta2)*var + scalar<DType>(1.f-param.beta2)*F<square>(
           F<clip>(grad, DType(param.clip_gradient)));
     } else {
-      mean = scalar<DType>(param.beta1)*mean + scalar<DType>(1.f-param.beta1) * grad;
+      mean = scalar<DType>(param.beta1*param.rho)*mean + scalar<DType>(1.f-param.beta1*param.rho) * grad;
       var = scalar<DType>(param.beta2)*var + scalar<DType>(1.f-param.beta2) * F<square>(grad);
     }
     Assign(out, req[0],
@@ -712,7 +716,8 @@ struct AdamDnsRspDnsKernel {
   MSHADOW_XINLINE static void Map(int i, const nnvm::dim_t row_length, DType* out_data,
     DType* mean_data, DType* var_data, const DType* weight_data, const IType* grad_idx,
     const DType* grad_data, const DType clip_gradient, const DType beta1, const DType beta2,
-    const DType lr, const DType wd, const DType epsilon, const DType rescale_grad) {
+    const DType rho, const DType lr, const DType wd, const DType epsilon,
+    const DType rescale_grad) {
     using nnvm::dim_t;
     using namespace mshadow_op;
     const dim_t row_offset = grad_idx[i] * row_length;
@@ -723,12 +728,13 @@ struct AdamDnsRspDnsKernel {
       const dim_t grad_i = i * row_length + j;
       const DType grad_rescaled = grad_data[grad_i] * rescale_grad + weight_data[data_i] * wd;
       if (clip_gradient >= 0.0f) {
-        mean_data[data_i] = beta1 * mean_data[data_i] + (1.f - beta1) *
+        mean_data[data_i] = beta1 * rho * mean_data[data_i] + (1.f - beta1 * rho) *
                             clip::Map(grad_rescaled, clip_gradient);
         var_data[data_i] =  beta2 * var_data[data_i] + (1.f - beta2) * square::Map(
                             clip::Map(grad_rescaled, clip_gradient));
       } else {
-        mean_data[data_i] = beta1 * mean_data[data_i] + (1.f - beta1) * grad_rescaled;
+        mean_data[data_i] = beta1 * rho * mean_data[data_i] +
+                            (1.f - beta1 * rho) * grad_rescaled;
         var_data[data_i] = beta2 * var_data[data_i] +
                            (1.f - beta2) * grad_rescaled * grad_rescaled;
       }
@@ -771,9 +777,9 @@ inline void AdamUpdateDnsRspDnsImpl(const AdamParam& param,
         Kernel<AdamDnsRspDnsKernel<req_type>, xpu>::Launch(s, num_rows, row_length,
           out_data, mean_data, var_data, weight_data, grad_idx, grad_val,
           static_cast<DType>(param.clip_gradient), static_cast<DType>(param.beta1),
-          static_cast<DType>(param.beta2), static_cast<DType>(param.lr),
-          static_cast<DType>(param.wd), static_cast<DType>(param.epsilon),
-          static_cast<DType>(param.rescale_grad));
+          static_cast<DType>(param.beta2), static_cast<DType>(param.rho),
+          static_cast<DType>(param.lr), static_cast<DType>(param.wd),
+          static_cast<DType>(param.epsilon), static_cast<DType>(param.rescale_grad));
       });
     });
   });

--- a/src/operator/optimizer_op.cc
+++ b/src/operator/optimizer_op.cc
@@ -147,13 +147,13 @@ are 1st and 2nd order moment estimates (mean and variance).
 .. math::
 
  g_t = \nabla J(W_{t-1})\\
- m_t = \beta_1 m_{t-1} + (1 - \beta_1) g_t\\
+ m_t = \beta_1 \cdot \rho^{t-1} m_{t-1} + (1 - \beta_1 \cdot \rho^{t-1}) g_t\\
  v_t = \beta_2 v_{t-1} + (1 - \beta_2) g_t^2\\
  W_t = W_{t-1} - \alpha \frac{ m_t }{ \sqrt{ v_t } + \epsilon }
 
 It updates the weights using::
 
- m = beta1*m + (1-beta1)*grad
+ m = beta1*(rho**(t-1))*m + (1-beta1*(rho**(t-1)))*grad
  v = beta2*v + (1-beta2)*(grad**2)
  w += - learning_rate * m / (sqrt(v) + epsilon)
 
@@ -161,7 +161,7 @@ If w, m and v are all of ``row_sparse`` storage type,
 only the row slices whose indices appear in grad.indices are updated (for w, m and v)::
 
  for row in grad.indices:
-     m[row] = beta1*m[row] + (1-beta1)*grad[row]
+     m[row] = beta1*(rho**(t-1))*m[row] + (1-beta1*(rho**(t-1)))*grad[row]
      v[row] = beta2*v[row] + (1-beta2)*(grad[row]**2)
      w[row] += - learning_rate * m[row] / (sqrt(v[row]) + epsilon)
 

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -330,11 +330,13 @@ def test_sparse_sgd():
 
 class PyAdam(mx.optimizer.Optimizer):
     """python reference implemenation of adam"""
-    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8,
-                 decay_factor=(1 - 1e-8), sparse_update=False, **kwargs):
+    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, rho=1-1e-8,
+                 epsilon=1e-8, decay_factor=(1 - 1e-8), sparse_update=False,
+                 **kwargs):
         super(PyAdam, self).__init__(learning_rate=learning_rate, **kwargs)
         self.beta1 = beta1
         self.beta2 = beta2
+        self.rho = rho
         self.epsilon = epsilon
         self.decay_factor = decay_factor
         self.sparse_update = sparse_update
@@ -390,8 +392,8 @@ class PyAdam(mx.optimizer.Optimizer):
             if self.clip_gradient is not None:
                 mx.nd.clip(grad[row], -self.clip_gradient, self.clip_gradient, out=grad[row])
             # update mean
-            mean[row] *= self.beta1
-            mean[row] += grad[row] * (1. - self.beta1)
+            mean[row] *= self.beta1 * self.rho**(t-1)
+            mean[row] += grad[row] * (1. - self.beta1 * self.rho**(t-1))
             # update variance
             variance[row] *= self.beta2
             variance[row] += (1 - self.beta2) * mx.nd.square(grad[row], out=grad[row])


### PR DESCRIPTION
@formath This implements the same change on perl side, since you changed the C++ which is source of the truth, it's nice to have user facing api changing at the same time.
In this case no tests will be broken even if this is not merged I think cause the rho defaults to 1 on C++ side and becomes a noop, but in the past C++ changes in optimizer apis were introducing breakage of perl tests.
Please kindly consider merging this pull into your pull request.
Thanks. 